### PR TITLE
Add GitHub Actions Workflow to Build and Save Docker Image as Artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build Pipeline
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  docker-build:
+    name: Build and Save Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+
+    - name: Set Image Tag
+      id: vars
+      run: echo "IMAGE_TAG=${GITHUB_REF_NAME}-${GITHUB_SHA::7}" >> $GITHUB_ENV
+      
+    - name: Build Docker Image
+      run: docker build -t trend-finder:${{ env.IMAGE_TAG }} .
+
+    - name: Save Docker Image
+      run: docker save trend-finder:${{ env.IMAGE_TAG }} | gzip > trend-finder-${{ env.IMAGE_TAG }}.tar.gz
+
+    - name: Upload Docker Image Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: trend-finder-image-${{ env.IMAGE_TAG }}
+        path: trend-finder-${{ env.IMAGE_TAG }}.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Pipeline
+name: Docker Build Pipeline
 
 on:
   push:
@@ -14,19 +14,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    # Checkout code
     - name: Checkout Code
       uses: actions/checkout@v3
 
+    # Get branch name and short commit hash, sanitize tag
     - name: Set Image Tag
       id: vars
-      run: echo "IMAGE_TAG=${GITHUB_REF_NAME}-${GITHUB_SHA::7}" >> $GITHUB_ENV
-      
+      run: |
+        IMAGE_TAG=$(echo "${GITHUB_REF_NAME}-${GITHUB_SHA::7}" | tr '/' '-')
+        echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+
+    # Build Docker image with sanitized tag
     - name: Build Docker Image
       run: docker build -t trend-finder:${{ env.IMAGE_TAG }} .
 
+    # Save Docker image as a tarball
     - name: Save Docker Image
       run: docker save trend-finder:${{ env.IMAGE_TAG }} | gzip > trend-finder-${{ env.IMAGE_TAG }}.tar.gz
 
+    # Upload Docker image as artifact
     - name: Upload Docker Image Artifact
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Docker Build Pipeline
+name: Build Pipeline
 
 on:
   push:
@@ -14,28 +14,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    # Checkout code
     - name: Checkout Code
-      uses: actions/checkout@v3
-
-    # Get branch name and short commit hash, sanitize tag
+      uses: actions/checkout@v4
+      
     - name: Set Image Tag
       id: vars
       run: |
         IMAGE_TAG=$(echo "${GITHUB_REF_NAME}-${GITHUB_SHA::7}" | tr '/' '-')
         echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
 
-    # Build Docker image with sanitized tag
     - name: Build Docker Image
       run: docker build -t trend-finder:${{ env.IMAGE_TAG }} .
 
-    # Save Docker image as a tarball
     - name: Save Docker Image
       run: docker save trend-finder:${{ env.IMAGE_TAG }} | gzip > trend-finder-${{ env.IMAGE_TAG }}.tar.gz
 
-    # Upload Docker image as artifact
     - name: Upload Docker Image Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: trend-finder-image-${{ env.IMAGE_TAG }}
         path: trend-finder-${{ env.IMAGE_TAG }}.tar.gz


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow that builds the project's Docker image and saves it as an artifact for easy reuse across development and testing workflows.

Key Changes:

- Automated Docker Build: The workflow dynamically builds a Docker image tagged with the branch name and short commit hash for better traceability (e.g., main-1a2b3c4).
- Artifact Storage: The built Docker image is saved as a compressed tarball (.tar.gz) and uploaded as a GitHub artifact, enabling developers or CI/CD pipelines to download and reuse the image without rebuilding it.
- Dynamic Tagging: Utilizes GitHub's context variables to incorporate branch names and commit hashes into the image tag, making it easier to associate images with specific code changes.